### PR TITLE
Extend config file to include information about where to find sources.

### DIFF
--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -127,15 +127,16 @@ class Config:
         sources: t.Sequence[str] = dict_['sources']
         launches: t.Sequence[str] = dict_['launches']
         environment: t.Mapping[str, str] = dict(dict_.get('environment', {}))
-        node_sources: t.Sequence[t.Dict[str, t.Any]] = list(dict_.get('node_sources', []))
+        node_sources_list: t.Sequence[t.Dict[str, t.Any]] = list(dict_.get('node_sources', []))
 
+        node_sources = {(nsi.package_name, nsi.node_name): nsi
+                        for nsi in (NodeSourceInfo.from_dict(d)
+                                    for d in node_sources_list)}
         return Config(image=image,
                       sources=sources,
                       launches=launches,
                       environment=environment,
-                      node_sources={(nsi.package_name, nsi.node_name): nsi
-                                    for nsi in (NodeSourceInfo.from_dict(d) for d in node_sources)
-                                    })
+                      node_sources=node_sources)
 
     @classmethod
     def from_yaml_string(cls, yml: str) -> 'Config':

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -55,7 +55,7 @@ class NodeSourceInfo:
         if not isinstance(dict_['node'], str):
             raise ValueError("expected 'node' to be a string")
         if not isinstance(dict_['sources'], list):
-            raise ValueError("expected 'sources' to be a string")
+            raise ValueError("expected 'sources' to be a list")
 
         return NodeSourceInfo(
             package_name=dict_['package'],
@@ -82,13 +82,13 @@ class Config:
     app: roswire.app.App
         The ROSWire application for this configuration.
     node_sources: List[NodeSourceInfo]
-        The list of information about the sources for nodes
+        Provides instructions on how to statically recover the architecture code for individual nodes
     """
     image: str
     sources: t.Sequence[str]
     launches: t.Sequence[str]
     environment: t.Mapping[str, str] = attr.ib(factory=dict)
-    node_sources: t.Mapping[t.Tuple[str, str], NodeSourceInfo] = attr.ib(factory=list)
+    node_sources: t.Mapping[t.Tuple[str, str], NodeSourceInfo] = attr.ib(factory=dict)
     app: roswire.app.App = attr.ib(init=False)
 
     @classmethod

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -80,14 +80,14 @@ class Config:
         A set of environment variables that should be used by the application.
     app: roswire.app.App
         The ROSWire application for this configuration.
-    sources: List[NodeSourceInfo]
+    node_sources: List[NodeSourceInfo]
         The list of information about the sources for nodes
     """
     image: str
     sources: t.Sequence[str]
     launches: t.Sequence[str]
     environment: t.Mapping[str, str] = attr.ib(factory=dict)
-    package_sources: t.Sequence[str] = attr.ib(factory=list)
+    node_sources: t.Sequence[str] = attr.ib(factory=list)
     app: roswire.app.App = attr.ib(init=False)
 
     @classmethod
@@ -118,21 +118,21 @@ class Config:
         if has_environment and not isinstance(dict_['environment'], dict):
             raise ValueError("expected 'environment' to be a mapping")
 
-        has_package_sources = 'package_sources' in dict_
-        if has_package_sources and not isinstance(dict['package_sources'], list):
-            raise ValueError("expected 'package_sources' to be a list")
+        has_node_sources = 'node_sources' in dict_
+        if has_node_sources and not isinstance(dict['node_sources'], list):
+            raise ValueError("expected 'node_sources' to be a list")
 
         image: str = dict_['image']
         sources: t.Sequence[str] = dict_['sources']
         launches: t.Sequence[str] = dict_['launches']
         environment: t.Mapping[str, str] = dict(dict_.get('environment', {}))
-        package_sources: t.Sequence[t.Dict[str, t.Any]] = list(dict_.get('package_sources', []))
+        node_sources: t.Sequence[t.Dict[str, t.Any]] = list(dict_.get('node_sources', []))
 
         return Config(image=image,
                       sources=sources,
                       launches=launches,
                       environment=environment,
-                      package_sources=[NodeSourceInfo.from_dict(d) for d in package_sources])
+                      package_sources=[NodeSourceInfo.from_dict(d) for d in node_sources])
 
     @classmethod
     def from_yaml_string(cls, yml: str) -> 'Config':

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -9,6 +9,7 @@ import attr
 import roswire
 import yaml
 
+
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class NodeSourceInfo:
     """
@@ -119,14 +120,14 @@ class Config:
             raise ValueError("expected 'environment' to be a mapping")
 
         has_node_sources = 'node_sources' in dict_
-        if has_node_sources and not isinstance(dict['node_sources'], list):
+        if has_node_sources and not isinstance(dict_['node_sources'], list):
             raise ValueError("expected 'node_sources' to be a list")
 
         image: str = dict_['image']
         sources: t.Sequence[str] = dict_['sources']
         launches: t.Sequence[str] = dict_['launches']
         environment: t.Mapping[str, str] = dict(dict_.get('environment', {}))
-        node_sources: t.Sequence[t.Dict[t.Tuple[str, str], t.Any]] = list(dict_.get('node_sources', []))
+        node_sources: t.Sequence[t.Dict[str, t.Any]] = list(dict_.get('node_sources', []))
 
         return Config(image=image,
                       sources=sources,

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -87,7 +87,7 @@ class Config:
     sources: t.Sequence[str]
     launches: t.Sequence[str]
     environment: t.Mapping[str, str] = attr.ib(factory=dict)
-    node_sources: t.Sequence[str] = attr.ib(factory=list)
+    node_sources: t.Mapping[str, NodeSourceInfo] = attr.ib(factory=list)
     app: roswire.app.App = attr.ib(init=False)
 
     @classmethod
@@ -132,7 +132,9 @@ class Config:
                       sources=sources,
                       launches=launches,
                       environment=environment,
-                      package_sources=[NodeSourceInfo.from_dict(d) for d in node_sources])
+                      node_sources={nsi.name: nsi
+                                    for nsi in (NodeSourceInfo.from_dict(d) for d in node_sources)
+                                    })
 
     @classmethod
     def from_yaml_string(cls, yml: str) -> 'Config':

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -87,7 +87,7 @@ class Config:
     sources: t.Sequence[str]
     launches: t.Sequence[str]
     environment: t.Mapping[str, str] = attr.ib(factory=dict)
-    node_sources: t.Mapping[str, NodeSourceInfo] = attr.ib(factory=list)
+    node_sources: t.Mapping[t.Tuple[str, str], NodeSourceInfo] = attr.ib(factory=list)
     app: roswire.app.App = attr.ib(init=False)
 
     @classmethod
@@ -126,13 +126,13 @@ class Config:
         sources: t.Sequence[str] = dict_['sources']
         launches: t.Sequence[str] = dict_['launches']
         environment: t.Mapping[str, str] = dict(dict_.get('environment', {}))
-        node_sources: t.Sequence[t.Dict[str, t.Any]] = list(dict_.get('node_sources', []))
+        node_sources: t.Sequence[t.Dict[t.Tuple[str, str], t.Any]] = list(dict_.get('node_sources', []))
 
         return Config(image=image,
                       sources=sources,
                       launches=launches,
                       environment=environment,
-                      node_sources={nsi.name: nsi
+                      node_sources={(nsi.package_name, nsi.node_name): nsi
                                     for nsi in (NodeSourceInfo.from_dict(d) for d in node_sources)
                                     })
 

--- a/src/rosdiscover/interpreter/model.py
+++ b/src/rosdiscover/interpreter/model.py
@@ -30,7 +30,7 @@ class Model:
     def find(package: str, name: str) -> 'Model':
         if (package, name) in Model._models:
             return Model._models[(package, name)]
-        except Exception:
+        else:
             m = (f"failed to find model for node type [{name}] "
                  f"in package [{package}]")
             logger.warning(m)

--- a/src/rosdiscover/interpreter/model.py
+++ b/src/rosdiscover/interpreter/model.py
@@ -30,7 +30,7 @@ class Model:
     def find(package: str, name: str) -> 'Model':
         if (package, name) in Model._models:
             return Model._models[(package, name)]
-        else:
+        except Exception:
             m = (f"failed to find model for node type [{name}] "
                  f"in package [{package}]")
             logger.warning(m)


### PR DESCRIPTION
Config yaml files will now be able to specify where nodes's source files are in the image, e.g.,

```
image: therobotcooperative/fetch
sources:
- /opt/ros/melodic/setup.bash
- /ros_ws/devel/setup.bash
launches:
- /ros_ws/src/fetch_gazebo/fetch_gazebo/launch/pickplace_playground.launch
node_sources:
  - package: fetch
    node: fetch_gazebo
    sources:
    - fetch_gazebo.cc
 ```