### PR TITLE
Added loading and storage of recovered node models into the rest of ROSDiscover

### DIFF
--- a/example/chatter.yml
+++ b/example/chatter.yml
@@ -3,4 +3,13 @@ sources:
   - /opt/ros/kinetic/setup.bash
   - /ros_ws/devel/setup.bash
 launches:
-  - /ros_ws/src/ros_tutorials/rospy_tutorials/001_talker_listener/talker_listener.launch
+  - /ros_ws/src/ros_tutorials/roscpp_tutorials/launch/talker_listener.launch
+node_sources:
+  - package: roscpp_tutorials
+    node: listener
+    sources:
+      - listener/listener.cpp
+  - package: roscpp_tutorials
+    node: talker
+    sources:
+      - talker/talker.cpp

--- a/src/rosdiscover/interpreter/interpreter.py
+++ b/src/rosdiscover/interpreter/interpreter.py
@@ -44,7 +44,7 @@ class Interpreter:
         self._app = app
         self.params = ParameterServer()
         self.nodes: Dict[str, NodeContext] = {}
-        self.models = ProjectModels(config, allow_recovery=False)
+        self.models = ProjectModels(config, allow_recovery=True)
 
     def open(self) -> None:
         self.models.open()

--- a/src/rosdiscover/project/models.py
+++ b/src/rosdiscover/project/models.py
@@ -36,7 +36,7 @@ class ProjectModels:
 
     def __attrs_post_init__(self) -> None:
         # TODO allow model database path to be specified
-        recovered_model_database_path = os.path.abspath("~/.rosdiscover/recovered-models")
+        recovered_model_database_path = os.path.expanduser("~/.rosdiscover/recovered-models")
         self._recovered_models = RecoveredNodeModelDatabase(recovered_model_database_path)
         self._recovery_tool = NodeRecoveryTool(app=self.config.app)
 

--- a/src/rosdiscover/recover/call.py
+++ b/src/rosdiscover/recover/call.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+import abc
+import typing as t
+
+import attr
+
+from .symbolic import SymbolicStatement, SymbolicString
+
+
+class SymbolicRosApiCall(abc.ABC, SymbolicStatement):
+    """Represents a symbolic call to a ROS API."""
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class RosInit(SymbolicRosApiCall):
+    name: SymbolicString
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class Publisher(SymbolicRosApiCall):
+    topic: SymbolicString
+    format_: str
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class Subscriber(SymbolicRosApiCall):
+    topic: SymbolicString
+    format_: str
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class ServiceProvider(SymbolicRosApiCall):
+    service: SymbolicString
+    format_: str
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class ServiceCaller(SymbolicRosApiCall):
+    service: SymbolicValue
+    format_: str
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class WriteParam(SymbolicRosApiCall):
+    param: SymbolicString
+    value: SymbolicValue
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class ReadParam(SymbolicRosApiCall):
+    param: SymbolicString
+    value: SymbolicValue
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class ReadParamWithDefault(SymbolicRosApiCall):
+    param: SymbolicString
+    value: SymbolicValue
+    default: SymbolicValue
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class HasParam(SymbolicRosApiCall):
+    param: SymbolicString

--- a/src/rosdiscover/recover/call.py
+++ b/src/rosdiscover/recover/call.py
@@ -11,7 +11,7 @@ from .symbolic import (
 )
 
 
-class SymbolicRosApiCall(abc.ABC, SymbolicStatement):
+class SymbolicRosApiCall(SymbolicStatement, abc.ABC):
     """Represents a symbolic call to a ROS API."""
 
 

--- a/src/rosdiscover/recover/call.py
+++ b/src/rosdiscover/recover/call.py
@@ -14,6 +14,7 @@ __all__ = (
 )
 
 import abc
+import typing as t
 
 import attr
 
@@ -33,11 +34,24 @@ class SymbolicRosApiCall(SymbolicStatement, abc.ABC):
 class RosInit(SymbolicRosApiCall):
     name: SymbolicString
 
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "kind": "ros-init",
+            "name": self.name,
+        }
+
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
 class Publisher(SymbolicRosApiCall):
     topic: SymbolicString
     format_: str
+
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "kind": "publishes-to",
+            "name": self.topic,
+            "format": self.format_,
+        }
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
@@ -45,11 +59,25 @@ class Subscriber(SymbolicRosApiCall):
     topic: SymbolicString
     format_: str
 
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "kind": "subscribes-to",
+            "name": self.topic,
+            "format": self.format_,
+        }
+
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
 class ServiceProvider(SymbolicRosApiCall):
     service: SymbolicString
     format_: str
+
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "kind": "provides-service",
+            "name": self.service,
+            "format": self.format_,
+        }
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
@@ -57,17 +85,38 @@ class ServiceCaller(SymbolicRosApiCall):
     service: SymbolicValue
     format_: str
 
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "kind": "calls-service",
+            "name": self.service,
+            "format": self.format_,
+        }
+
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
 class WriteParam(SymbolicRosApiCall):
     param: SymbolicString
     value: SymbolicValue
 
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "kind": "writes-to-param",
+            "param": self.param.to_dict(),
+            "value": self.value.to_dict(),
+        }
+
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
 class ReadParam(SymbolicRosApiCall, SymbolicValue):
     param: SymbolicString
     value: SymbolicValue
+
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "kind": "reads-param",
+            "param": self.param.to_dict(),
+            "value": self.value.to_dict(),
+        }
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
@@ -76,12 +125,32 @@ class ReadParamWithDefault(SymbolicRosApiCall, SymbolicValue):
     value: SymbolicValue
     default: SymbolicValue
 
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "kind": "reads-param-with-default",
+            "param": self.param.to_dict(),
+            "value": self.value.to_dict(),
+            "default": self.default.to_dict(),
+        }
+
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
 class HasParam(SymbolicRosApiCall, SymbolicBool):
     param: SymbolicString
 
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "kind": "checks-for-param",
+            "param": self.param.to_dict(),
+        }
+
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
 class DeleteParam(SymbolicRosApiCall):
     param: SymbolicString
+
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "kind": "deletes-param",
+            "param": self.param.to_dict(),
+        }

--- a/src/rosdiscover/recover/call.py
+++ b/src/rosdiscover/recover/call.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 import abc
-import typing as t
 
 import attr
 
-from .symbolic import SymbolicStatement, SymbolicString
+from .symbolic import (
+    SymbolicBool,
+    SymbolicStatement,
+    SymbolicString,
+    SymbolicValue,
+)
 
 
 class SymbolicRosApiCall(abc.ABC, SymbolicStatement):
@@ -47,18 +51,18 @@ class WriteParam(SymbolicRosApiCall):
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
-class ReadParam(SymbolicRosApiCall):
+class ReadParam(SymbolicRosApiCall, SymbolicValue):
     param: SymbolicString
     value: SymbolicValue
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
-class ReadParamWithDefault(SymbolicRosApiCall):
+class ReadParamWithDefault(SymbolicRosApiCall, SymbolicValue):
     param: SymbolicString
     value: SymbolicValue
     default: SymbolicValue
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
-class HasParam(SymbolicRosApiCall):
+class HasParam(SymbolicRosApiCall, SymbolicBool):
     param: SymbolicString

--- a/src/rosdiscover/recover/call.py
+++ b/src/rosdiscover/recover/call.py
@@ -37,7 +37,7 @@ class RosInit(SymbolicRosApiCall):
     def to_dict(self) -> t.Dict[str, t.Any]:
         return {
             "kind": "ros-init",
-            "name": self.name,
+            "name": self.name.to_dict(),
         }
 
 
@@ -49,7 +49,7 @@ class Publisher(SymbolicRosApiCall):
     def to_dict(self) -> t.Dict[str, t.Any]:
         return {
             "kind": "publishes-to",
-            "name": self.topic,
+            "name": self.topic.to_dict(),
             "format": self.format_,
         }
 
@@ -62,7 +62,7 @@ class Subscriber(SymbolicRosApiCall):
     def to_dict(self) -> t.Dict[str, t.Any]:
         return {
             "kind": "subscribes-to",
-            "name": self.topic,
+            "name": self.topic.to_dict(),
             "format": self.format_,
         }
 
@@ -75,7 +75,7 @@ class ServiceProvider(SymbolicRosApiCall):
     def to_dict(self) -> t.Dict[str, t.Any]:
         return {
             "kind": "provides-service",
-            "name": self.service,
+            "name": self.service.to_dict(),
             "format": self.format_,
         }
 
@@ -88,7 +88,7 @@ class ServiceCaller(SymbolicRosApiCall):
     def to_dict(self) -> t.Dict[str, t.Any]:
         return {
             "kind": "calls-service",
-            "name": self.service,
+            "name": self.service.to_dict(),
             "format": self.format_,
         }
 

--- a/src/rosdiscover/recover/call.py
+++ b/src/rosdiscover/recover/call.py
@@ -1,4 +1,18 @@
 # -*- coding: utf-8 -*-
+__all__ = (
+    "DeleteParam",
+    "HasParam",
+    "Publisher",
+    "ReadParam",
+    "ReadParamWithDefault",
+    "RosInit",
+    "ServiceCaller",
+    "ServiceProvider",
+    "Subscriber",
+    "SymbolicRosApiCall",
+    "WriteParam",
+)
+
 import abc
 
 import attr
@@ -65,4 +79,9 @@ class ReadParamWithDefault(SymbolicRosApiCall, SymbolicValue):
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
 class HasParam(SymbolicRosApiCall, SymbolicBool):
+    param: SymbolicString
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class DeleteParam(SymbolicRosApiCall):
     param: SymbolicString

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -6,16 +6,31 @@ __all__ = ("SymbolicProgramLoader",)
 import typing as t
 
 from .symbolic import (
+    SymbolicCompound,
     SymbolicFunction,
+    SymbolicParameter,
     SymbolicProgram,
 )
 
 
 class SymbolicProgramLoader:
-    def _load_function(self, dict_: t.Mapping[str, t.Any]) -> SymbolicFunction:
+    def _load_parameter(self, dict_: t.Mapping[str, t.Any]) -> SymbolicParameter:
         raise NotImplementedError
 
+    def _load_compound(self, dict_: t.Mapping[str, t.Any]) -> SymbolicCompound:
+        raise NotImplementedError
+
+    def _load_function(self, dict_: t.Mapping[str, t.Any]) -> SymbolicFunction:
+        name: str = dict_["name"]
+        parameters = [self._load_parameter(d) for d in dict_["parameters"]]
+        body = self._load_compound(dict_["body"])
+        return SymbolicFunction.build(
+            name,
+            parameters,
+            body,
+        )
+
     def load(self, dict_: t.Mapping[str, t.Any]) -> SymbolicProgram:
-        functions = [self._load_function(d) for d in dict_["functions"]]
-        name_to_function = {function.name: function for function in functions}
-        return SymbolicProgram(name_to_function)
+        return SymbolicProgram.build(
+            self._load_function(d) for d in dict_["functions"]
+        )

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -6,6 +6,7 @@ __all__ = ("SymbolicProgramLoader",)
 import typing as t
 
 from .symbolic import (
+    StringLiteral,
     SymbolicCompound,
     SymbolicFunction,
     SymbolicParameter,
@@ -18,8 +19,19 @@ class SymbolicProgramLoader:
     def _load_parameter(self, dict_: t.Mapping[str, t.Any]) -> SymbolicParameter:
         raise NotImplementedError
 
+    def _load_string_literal(dict_: t.Mapping[str, t.Any]) -> StringLiteral:
+        assert dict_["kind"] == "string-literal"
+        return StringLiteral(dict_["literal"])
+
     def _load_value(self, dict_: t.Mapping[str, t.Any]) -> SymbolicValue:
-        raise NotImplementedError
+        kind: str = dict_["kind"]
+        try:
+            loader: t.Callable[[t.Mapping[str, t.Any]], SymbolicValue] = ({
+                "string-literal": self._load_string_literal,
+            })[kind]
+        except KeyError:
+            raise ValueError(f"failed to load value type: {kind}")
+        return loader(dict_)
 
     def _load_assignment(self, dict_: t.Mapping[str, t.Any]) -> SymbolicAssignment:
         assert dict_["kind"] == "assignment"

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+__all__ = ("SymbolicProgramLoader",)
+
+import json
+import typing as t
+
+from .symbolic import SymbolicProgram
+
+
+class SymbolicProgramLoader:
+    def load_from_dict(self, dict_: t.Mapping[str, t.Any]) -> SymbolicProgram:
+        raise NotImplementedError
+
+    def load(self, filename: str) -> SymbolicProgram:
+        with open(filename, "r") as f:
+            return self.load_from_dict(json.load(f))

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -12,6 +12,8 @@ from .symbolic import (
     SymbolicParameter,
     SymbolicProgram,
     SymbolicValue,
+    SymbolicValueType,
+    SymbolicVariableReference,
 )
 
 
@@ -23,11 +25,17 @@ class SymbolicProgramLoader:
         assert dict_["kind"] == "string-literal"
         return StringLiteral(dict_["literal"])
 
+    def _load_variable_reference(dict_: t.Mapping[str, t.Any]) -> SymbolicVariableReference:
+        assert dict_["kind"] == "variable-reference"
+        type_ = SymbolicValueType.from_name(dict_["type"])
+        return SymbolicVariableReference(dict_["variable"], type_)
+
     def _load_value(self, dict_: t.Mapping[str, t.Any]) -> SymbolicValue:
         kind: str = dict_["kind"]
         try:
             loader: t.Callable[[t.Mapping[str, t.Any]], SymbolicValue] = ({
                 "string-literal": self._load_string_literal,
+                "variable-reference": self._load_variable_reference,
             })[kind]
         except KeyError:
             raise ValueError(f"failed to load value type: {kind}")

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -10,6 +10,7 @@ from .symbolic import (
     SymbolicFunction,
     SymbolicParameter,
     SymbolicProgram,
+    SymbolicValue,
 )
 
 
@@ -17,8 +18,19 @@ class SymbolicProgramLoader:
     def _load_parameter(self, dict_: t.Mapping[str, t.Any]) -> SymbolicParameter:
         raise NotImplementedError
 
-    def _load_compound(self, dict_: t.Mapping[str, t.Any]) -> SymbolicCompound:
+    def _load_value(self, dict_: t.Mapping[str, t.Any]) -> SymbolicValue:
         raise NotImplementedError
+
+    def _load_assignment(self, dict_: t.Mapping[str, t.Any]) -> SymbolicAssignment:
+        assert dict_["kind"] == "assignment"
+        variable = dict_["variable"]
+        value = self._load_value(dict_["value"])
+        return SymbolicAssignment(variable, value)
+
+    def _load_compound(self, dict_: t.Mapping[str, t.Any]) -> SymbolicCompound:
+        assert dict_["kind"] == "compound"
+        statements = [self._load_statement(d) for d in dict_["statements"]]
+        return SymbolicCompound(statements)
 
     def _load_function(self, dict_: t.Mapping[str, t.Any]) -> SymbolicFunction:
         name: str = dict_["name"]

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -132,7 +132,7 @@ class SymbolicProgramLoader:
         # FIXME add support for arguments both here and in C++ recovery code
         return SymbolicFunctionCall(
             callee=dict_["callee"],
-            arguments=[],
+            arguments={},
         )
 
     def _load_statement(self, dict_: t.Mapping[str, t.Any]) -> SymbolicStatement:
@@ -155,6 +155,8 @@ class SymbolicProgramLoader:
             return self._load_writes_to_param(dict_)
         elif kind == "deletes-param":
             return self._load_deletes_param(dict_)
+        elif kind == "checks-for-param":
+            return self._load_checks_for_param(dict_)
         elif kind == "compound":
             return self._load_compound(dict_)
         else:

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -7,10 +7,12 @@ import typing as t
 
 from .symbolic import (
     StringLiteral,
+    SymbolicAssignment,
     SymbolicCompound,
     SymbolicFunction,
     SymbolicParameter,
     SymbolicProgram,
+    SymbolicStatement,
     SymbolicValue,
     SymbolicValueType,
     SymbolicVariableReference,
@@ -29,11 +31,11 @@ class SymbolicProgramLoader:
             type_=type_,
         )
 
-    def _load_string_literal(dict_: t.Mapping[str, t.Any]) -> StringLiteral:
+    def _load_string_literal(self, dict_: t.Mapping[str, t.Any]) -> StringLiteral:
         assert dict_["kind"] == "string-literal"
         return StringLiteral(dict_["literal"])
 
-    def _load_variable_reference(dict_: t.Mapping[str, t.Any]) -> SymbolicVariableReference:
+    def _load_variable_reference(self, dict_: t.Mapping[str, t.Any]) -> SymbolicVariableReference:
         assert dict_["kind"] == "variable-reference"
         type_ = SymbolicValueType.from_name(dict_["type"])
         return SymbolicVariableReference(dict_["variable"], type_)
@@ -54,6 +56,9 @@ class SymbolicProgramLoader:
         variable = dict_["variable"]
         value = self._load_value(dict_["value"])
         return SymbolicAssignment(variable, value)
+
+    def _load_statement(self, dict_: t.Mapping[str, t.Any]) -> SymbolicStatement:
+        raise NotImplementedError
 
     def _load_compound(self, dict_: t.Mapping[str, t.Any]) -> SymbolicCompound:
         assert dict_["kind"] == "compound"

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -19,7 +19,15 @@ from .symbolic import (
 
 class SymbolicProgramLoader:
     def _load_parameter(self, dict_: t.Mapping[str, t.Any]) -> SymbolicParameter:
-        raise NotImplementedError
+        assert dict_["kind"] == "parameter"
+        index: int = dict_["index"]
+        name: str = dict_["name"]
+        type_ = SymbolicValueType.from_name(dict_["type"])
+        return SymbolicParameter(
+            index=index,
+            name=name,
+            type_=type_,
+        )
 
     def _load_string_literal(dict_: t.Mapping[str, t.Any]) -> StringLiteral:
         assert dict_["kind"] == "string-literal"

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -3,16 +3,19 @@ from __future__ import annotations
 
 __all__ = ("SymbolicProgramLoader",)
 
-import json
 import typing as t
 
-from .symbolic import SymbolicProgram
+from .symbolic import (
+    SymbolicFunction,
+    SymbolicProgram,
+)
 
 
 class SymbolicProgramLoader:
-    def load_from_dict(self, dict_: t.Mapping[str, t.Any]) -> SymbolicProgram:
+    def _load_function(self, dict_: t.Mapping[str, t.Any]) -> SymbolicFunction:
         raise NotImplementedError
 
-    def load(self, filename: str) -> SymbolicProgram:
-        with open(filename, "r") as f:
-            return self.load_from_dict(json.load(f))
+    def load(self, dict_: t.Mapping[str, t.Any]) -> SymbolicProgram:
+        functions = [self._load_function(d) for d in dict_["functions"]]
+        name_to_function = {function.name: function for function in functions}
+        return SymbolicProgram(name_to_function)

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -56,7 +56,7 @@ class SymbolicProgramLoader:
             type_=type_,
         )
 
-    def _load_string(self, dict_: t.Mapping[str, t.Any]) -> SymbolicValue:
+    def _load_string(self, dict_: t.Mapping[str, t.Any]) -> SymbolicString:
         value = self._load_value(dict_)
         assert isinstance(value, SymbolicString)
         return value
@@ -83,12 +83,18 @@ class SymbolicProgramLoader:
         name = self._load_string(dict_["name"])
         return RosInit(name)
 
+    def _load_publishes_to(self, dict_: t.Mapping[str, t.Any]) -> Publisher:
+        assert dict_["kind"] == "publishes-to"
+        topic = self._load_string(dict_["name"])
+        return Publisher(topic=topic, format_=dict_["format"])
+
     def _load_statement(self, dict_: t.Mapping[str, t.Any]) -> SymbolicStatement:
         kind: str = dict_["kind"]
 
         try:
             loader: t.Callable[[t.Mapping[str, t.Any]], SymbolicValue] = ({
                 "ros-init": self._load_rosinit,
+                "publishes-to": self._load_publishes_to,
             })[kind]
         except KeyError:
             raise ValueError(f"failed to load statement: {dict_}")

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -22,6 +22,7 @@ from .symbolic import (
     SymbolicAssignment,
     SymbolicCompound,
     SymbolicFunction,
+    SymbolicFunctionCall,
     SymbolicParameter,
     SymbolicProgram,
     SymbolicStatement,
@@ -127,10 +128,19 @@ class SymbolicProgramLoader:
         param = self._load_string(dict_["name"])
         return HasParam(param)
 
+    def _load_function_call(self, dict_: t.Mapping[str, t.Any]) -> SymbolicFunctionCall:
+        # FIXME add support for arguments both here and in C++ recovery code
+        return SymbolicFunctionCall(
+            callee=dict_["callee"],
+            arguments=[],
+        )
+
     def _load_statement(self, dict_: t.Mapping[str, t.Any]) -> SymbolicStatement:
         kind: str = dict_["kind"]
         if kind == "assignment":
             return self._load_assignment(dict_)
+        elif kind == "call":
+            return self._load_function_call(dict_)
         elif kind == "ros-init":
             return self._load_rosinit(dict_)
         elif kind == "publishes-to":

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -6,6 +6,7 @@ __all__ = ("SymbolicProgramLoader",)
 import typing as t
 
 from .call import (
+    DeleteParam,
     HasParam,
     Publisher,
     ReadParam,
@@ -73,20 +74,56 @@ class SymbolicProgramLoader:
         return loader(dict_)
 
     def _load_assignment(self, dict_: t.Mapping[str, t.Any]) -> SymbolicAssignment:
-        assert dict_["kind"] == "assignment"
         variable = dict_["variable"]
         value = self._load_value(dict_["value"])
         return SymbolicAssignment(variable, value)
 
     def _load_rosinit(self, dict_: t.Mapping[str, t.Any]) -> RosInit:
-        assert dict_["kind"] == "ros-init"
         name = self._load_string(dict_["name"])
         return RosInit(name)
 
     def _load_publishes_to(self, dict_: t.Mapping[str, t.Any]) -> Publisher:
-        assert dict_["kind"] == "publishes-to"
         topic = self._load_string(dict_["name"])
-        return Publisher(topic=topic, format_=dict_["format"])
+        return Publisher(topic, dict_["format"])
+
+    def _load_subscribes_to(self, dict_: t.Mapping[str, t.Any]) -> Subscriber:
+        topic = self._load_string(dict_["name"])
+        return Subscriber(topic, dict_["format"])
+
+    def _load_calls_service(self, dict_: t.Mapping[str, t.Any]) -> ServiceCaller:
+        service = self._load_string(dict_["name"])
+        return ServiceCaller(service, dict_["format"])
+
+    def _load_provides_service(self, dict_: t.Mapping[str, t.Any]) -> ServiceProvider:
+        service = self._load_string(dict_["name"])
+        return ServiceProvider(service, dict_["format"])
+
+    def _load_reads_param(self, dict_: t.Mapping[str, t.Any]) -> ReadParam:
+        param = self._load_string(dict_["name"])
+        value = self._load_value(dict_["value"])
+        return ReadParam(param, value)
+
+    def _load_reads_param_with_default(
+        self,
+        dict_: t.Mapping[str, t.Any],
+    ) -> ReadParamWithDefault:
+        param = self._load_string(dict_["name"])
+        value = self._load_value(dict_["value"])
+        default = self._load_value(dict_["default"])
+        return ReadParamWithDefault(param, value, default)
+
+    def _load_writes_to_param(self, dict_: t.Mapping[str, t.Any]) -> WriteParam:
+        param = self._load_string(dict_["name"])
+        value = self._load_value(dict_["value"])
+        return WriteParam(param, value)
+
+    def _load_deletes_param(self, dict_: t.Mapping[str, t.Any]) -> DeleteParam:
+        param = self._load_string(dict_["name"])
+        return DeleteParam(param)
+
+    def _load_checks_for_param(self, dict_: t.Mapping[str, t.Any]) -> HasParam:
+        param = self._load_string(dict_["name"])
+        return HasParam(param)
 
     def _load_statement(self, dict_: t.Mapping[str, t.Any]) -> SymbolicStatement:
         kind: str = dict_["kind"]
@@ -94,6 +131,22 @@ class SymbolicProgramLoader:
             return self._load_rosinit(dict_)
         elif kind == "publishes-to":
             return self._load_publishes_to(dict_)
+        elif kind == "subscribes-to":
+            return self._load_subscribes_to(dict_)
+        elif kind == "calls-service":
+            return self._load_calls_service(dict_)
+        elif kind == "provides-service":
+            return self._load_provides_service(dict_)
+        elif kind == "reads-param":
+            return self._load_reads_param(dict_)
+        elif kind == "reads-param-with-default":
+            return self._load_reads_param_with_default(dict_)
+        elif kind == "writes-to-param":
+            return self._load_writes_to_param(dict_)
+        elif kind == "deletes-param":
+            return self._load_deletes_param(dict_)
+        elif kind == "checks-for-param":
+            return self._load_checks_for_param(dict_)
         else:
             raise ValueError(f"unknown statement kind: {kind}")
 

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -34,7 +34,6 @@ from .symbolic import (
 
 class SymbolicProgramLoader:
     def _load_parameter(self, dict_: t.Mapping[str, t.Any]) -> SymbolicParameter:
-        assert dict_["kind"] == "parameter"
         index: int = dict_["index"]
         name: str = dict_["name"]
         type_ = SymbolicValueType.from_name(dict_["type"])
@@ -146,6 +145,8 @@ class SymbolicProgramLoader:
             return self._load_writes_to_param(dict_)
         elif kind == "deletes-param":
             return self._load_deletes_param(dict_)
+        elif kind == "compound":
+            return self._load_compound(dict_)
         else:
             raise ValueError(f"unknown statement kind: {kind}")
 
@@ -165,6 +166,7 @@ class SymbolicProgramLoader:
         )
 
     def load(self, dict_: t.Mapping[str, t.Any]) -> SymbolicProgram:
+        dict_ = dict_["program"]
         return SymbolicProgram.build(
             self._load_function(d) for d in dict_["functions"]
         )

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -90,16 +90,12 @@ class SymbolicProgramLoader:
 
     def _load_statement(self, dict_: t.Mapping[str, t.Any]) -> SymbolicStatement:
         kind: str = dict_["kind"]
-
-        try:
-            loader: t.Callable[[t.Mapping[str, t.Any]], SymbolicValue] = ({
-                "ros-init": self._load_rosinit,
-                "publishes-to": self._load_publishes_to,
-            })[kind]
-        except KeyError:
-            raise ValueError(f"failed to load statement: {dict_}")
-
-        return loader(dict_)
+        if kind == "ros-init":
+            return self._load_rosinit(dict_)
+        elif kind == "publishes-to":
+            return self._load_publishes_to(dict_)
+        else:
+            raise ValueError(f"unknown statement kind: {kind}")
 
     def _load_compound(self, dict_: t.Mapping[str, t.Any]) -> SymbolicCompound:
         assert dict_["kind"] == "compound"

--- a/src/rosdiscover/recover/model.py
+++ b/src/rosdiscover/recover/model.py
@@ -4,6 +4,7 @@ __all__ = ("RecoveredNodeModel",)
 import json
 import typing as t
 
+from loguru import logger
 import attr
 
 from .loader import SymbolicProgramLoader
@@ -43,6 +44,7 @@ class RecoveredNodeModel(NodeModel):
 
     def save(self, filename: str) -> None:
         dict_ = self.to_dict()
+        logger.debug(f"converted model to JSON-ready dict: {dict_}")
         with open(filename, "w") as f:
             json.dump(dict_, f)
 

--- a/src/rosdiscover/recover/model.py
+++ b/src/rosdiscover/recover/model.py
@@ -6,6 +6,8 @@ import typing as t
 
 import attr
 
+from .loader import SymbolicProgramLoader
+from .symbolic import SymbolicProgram
 from ..interpreter import NodeModel, NodeContext
 
 
@@ -29,12 +31,15 @@ class RecoveredNodeModel(NodeModel):
         directory,
     node_name: str
         The name of the node.
+    program: SymbolicProgram
+        A parameterized, executable description of the node's architectural effects.
     """
     image_sha256: str
     package_name: str
     package_abs_path: str
     source_paths: t.Collection[str]
     node_name: str
+    program: SymbolicProgram
 
     def save(self, filename: str) -> None:
         dict_ = self.to_dict()
@@ -52,6 +57,7 @@ class RecoveredNodeModel(NodeModel):
                 "path": self.package_abs_path,
             },
             "sources": list(self.source_paths),
+            "program": self.program.to_dict(),
         }
 
     @classmethod
@@ -66,12 +72,14 @@ class RecoveredNodeModel(NodeModel):
         package_name = dict_["package"]["name"]
         package_abs_path = dict_["package"]["path"]
         source_paths = dict_["sources"]
+        program = SymbolicProgramLoader().load(dict_["program"])
         return RecoveredNodeModel(
             image_sha256=image_sha256,
             node_name=node_name,
             package_name=package_name,
             package_abs_path=package_abs_path,
             source_paths=source_paths,
+            program=program,
         )
 
     def eval(self, context: NodeContext) -> None:

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+__all__ = ("SymbolicStatement", "SymbolicFunction")
+
+import abc
+import typing as t
+
+import attr
+
+
+class SymbolicValue(abc.ABC):
+    """Represents a symbolic value in a function summary."""
+
+
+class SymbolicStatement(abc.ABC):
+    """Represents a statement in a symbolic function summary."""
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class SymbolicCompound(t.Sequence[SymbolicStatement]):
+    """Represents a sequence of symbolic statements."""
+    _statements: t.Sequence[SymbolicStatement]
+
+    def __len__(self) -> int:
+        return len(self._statements)
+
+    def __getitem__(self, at: t.Union[int, slice]) -> SymbolicStatement:
+        return self._statements[at]
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class SymbolicFunctionCall(SymbolicFunction):
+    """Represents a call to a symbolic function.
+
+    Attributes
+    ----------
+    callee: str
+        The name of the function that is being called.
+    arguments: t.Mapping[str, SymbolicValue]
+        The arguments that should be used during the function call, indexed by
+        the name of the corresponding argument.
+    """
+    callee: str
+    arguments: t.Mapping[str, SymbolicValue]
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class SymbolicFunction:
+    name: str
+    body: SymbolicCompound

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -187,3 +187,6 @@ class SymbolicProgram:
     def build(cls, functions: t.Iterable[SymbolicFunction]) -> SymbolicProgram:
         name_to_function = {function.name: function for function in functions}
         return SymbolicProgram(name_to_function)
+
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        raise NotImplementedError

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -88,6 +88,16 @@ class SymbolicFunction:
     parameters: t.Mapping[str, SymbolicParameter]
     body: SymbolicCompound
 
+    @classmethod
+    def build(
+        self,
+        name: str,
+        parameters: t.Iterable[SymbolicParameter],
+        body: SymbolicCompound,
+    ) -> SymbolicFunction:
+        name_to_parameter = {param.name: param for param in parameters}
+        return SymbolicFunction(name, name_to_parameter, body)
+
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
 class SymbolicProgram:
@@ -99,3 +109,8 @@ class SymbolicProgram:
         The symbolic functions within this program, indexed by name.
     """
     functions: t.Mapping[str, SymbolicFunction]
+
+    @classmethod
+    def build(self, functions: t.Iterable[SymbolicFunction]) -> SymbolicProgram:
+        name_to_function = {function.name: function for function in functions}
+        return SymbolicProgram(name_to_function)

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -16,6 +16,7 @@ __all__ = (
 from enum import auto
 import abc
 import enum
+import typing
 import typing as t
 
 import attr
@@ -67,7 +68,7 @@ class SymbolicStatement(abc.ABC):
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
-class SymbolicAssignment:
+class SymbolicAssignment(SymbolicStatement):
     """Represents an assignment to a symbolic variable.
 
     Attributes
@@ -89,11 +90,13 @@ class SymbolicCompound(t.Sequence[SymbolicStatement]):
     def __len__(self) -> int:
         return len(self._statements)
 
-    @t.overload
-    def __getitem__(self, at: int) -> SymbolicStatement: ...
+    @typing.overload
+    def __getitem__(self, at: int) -> SymbolicStatement:
+        ...
 
-    @t.overload
-    def __getitem__(self, at: slice) -> t.Sequence[SymbolicStatement]: ...
+    @typing.overload
+    def __getitem__(self, at: slice) -> t.Sequence[SymbolicStatement]:
+        ...
 
     def __getitem__(
         self,

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -23,14 +23,21 @@ import attr
 
 class SymbolicValueType(enum.Enum):
     BOOL = auto()
-    STRING = auto()
     INTEGER = auto()
+    STRING = auto()
+    UNSUPPORTED = auto()
 
     @classmethod
     def from_name(cls, name: str) -> SymbolicValueType:
         name_to_type = {
-            "bool"
+            "bool": cls.BOOL,
+            "integer": cls.INTEGER,
+            "string": cls.STRING,
+            "unsupported": cls.UNSUPPORTED,
         }
+        if name in name_to_type:
+            raise ValueError(f"unknown value type: {name}")
+        return name_to_type[name]
 
 
 class SymbolicValue(abc.ABC):
@@ -87,7 +94,7 @@ class SymbolicCompound(t.Sequence[SymbolicStatement]):
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
-class SymbolicFunctionCall(SymbolicFunction):
+class SymbolicFunctionCall(SymbolicStatement):
     """Represents a call to a symbolic function.
 
     Attributes
@@ -144,7 +151,7 @@ class SymbolicFunction:
 
     @classmethod
     def build(
-        self,
+        cls,
         name: str,
         parameters: t.Iterable[SymbolicParameter],
         body: SymbolicCompound,
@@ -165,6 +172,6 @@ class SymbolicProgram:
     functions: t.Mapping[str, SymbolicFunction]
 
     @classmethod
-    def build(self, functions: t.Iterable[SymbolicFunction]) -> SymbolicProgram:
+    def build(cls, functions: t.Iterable[SymbolicFunction]) -> SymbolicProgram:
         name_to_function = {function.name: function for function in functions}
         return SymbolicProgram(name_to_function)

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -7,6 +7,7 @@ __all__ = (
     "SymbolicFunction",
     "SymbolicStatement",
     "SymbolicString",
+    "SymbolicParameter",
     "SymbolicProgram",
 )
 
@@ -65,6 +66,12 @@ class SymbolicFunctionCall(SymbolicFunction):
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
+class SymbolicParameter:
+    """Provides the definition for a symbolic function parameter."""
+    name: str
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
 class SymbolicFunction:
     """Provides the definition of a single symbolic function.
 
@@ -72,10 +79,13 @@ class SymbolicFunction:
     ----------
     name: str
         The fully-qualified name of the function.
+    parameters: t.Mapping[str, SymbolicParameter]
+        The parameters of this function, indexed by name.
     body: SymbolicCompound
         The definition of the function.
     """
     name: str
+    parameters: t.Mapping[str, SymbolicParameter]
     body: SymbolicCompound
 
 

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -2,14 +2,15 @@
 from __future__ import annotations
 
 __all__ = (
+    "StringLiteral",
     "SymbolicAssignment",
     "SymbolicBool",
     "SymbolicCompound",
     "SymbolicFunction",
-    "SymbolicStatement",
-    "SymbolicString",
     "SymbolicParameter",
     "SymbolicProgram",
+    "SymbolicStatement",
+    "SymbolicString",
 )
 
 import abc
@@ -26,6 +27,12 @@ class SymbolicString(abc.ABC, SymbolicValue):
     """Represents a symbolic string value."""
 
 
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class StringLiteral(SymbolicString):
+    """Represents a literal string value."""
+    value: str
+
+
 class SymbolicInteger(abc.ABC, SymbolicValue):
     """Represents a symbolic integer value."""
 
@@ -38,7 +45,8 @@ class SymbolicStatement(abc.ABC):
     """Represents a statement in a symbolic function summary."""
 
 
-class SymbolicAssignment(abc.ABC):
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class SymbolicAssignment:
     """Represents an assignment to a symbolic variable.
 
     Attributes

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -36,7 +36,7 @@ class SymbolicValueType(enum.Enum):
             "string": cls.STRING,
             "unsupported": cls.UNSUPPORTED,
         }
-        if name in name_to_type:
+        if name not in name_to_type:
             raise ValueError(f"unknown value type: {name}")
         return name_to_type[name]
 
@@ -83,7 +83,7 @@ class SymbolicAssignment(SymbolicStatement):
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
-class SymbolicCompound(t.Sequence[SymbolicStatement]):
+class SymbolicCompound(t.Sequence[SymbolicStatement], SymbolicStatement):
     """Represents a sequence of symbolic statements."""
     _statements: t.Sequence[SymbolicStatement]
 

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-__all__ = ("SymbolicStatement", "SymbolicFunction")
+__all__ = (
+    "SymbolicBool",
+    "SymbolicFunction",
+    "SymbolicStatement",
+    "SymbolicString",
+)
 
 import abc
 import typing as t
@@ -9,6 +14,18 @@ import attr
 
 class SymbolicValue(abc.ABC):
     """Represents a symbolic value in a function summary."""
+
+
+class SymbolicString(abc.ABC, SymbolicValue):
+    """Represents a symbolic string value."""
+
+
+class SymbolicInteger(abc.ABC, SymbolicValue):
+    """Represents a symbolic integer value."""
+
+
+class SymbolicBool(abc.ABC, SymbolicValue):
+    """Represents a symbolic boolean value."""
 
 
 class SymbolicStatement(abc.ABC):

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 __all__ = (
+    "SymbolicAssignment",
     "SymbolicBool",
     "SymbolicCompound",
     "SymbolicFunction",
@@ -35,6 +36,20 @@ class SymbolicBool(abc.ABC, SymbolicValue):
 
 class SymbolicStatement(abc.ABC):
     """Represents a statement in a symbolic function summary."""
+
+
+class SymbolicAssignment(abc.ABC):
+    """Represents an assignment to a symbolic variable.
+
+    Attributes
+    ----------
+    variable: str
+        The name of the variable whose value is being assigned.
+    value: SymbolicValue
+        The value of the variable, provided as a symbolic expression.
+    """
+    variable: str
+    value: SymbolicValue
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -13,10 +13,24 @@ __all__ = (
     "SymbolicString",
 )
 
+from enum import auto
 import abc
+import enum
 import typing as t
 
 import attr
+
+
+class SymbolicValueType(enum.Enum):
+    BOOL = auto()
+    STRING = auto()
+    INTEGER = auto()
+
+    @classmethod
+    def from_name(cls, name: str) -> SymbolicValueType:
+        name_to_type = {
+            "bool"
+        }
 
 
 class SymbolicValue(abc.ABC):
@@ -88,10 +102,27 @@ class SymbolicFunctionCall(SymbolicFunction):
     arguments: t.Mapping[str, SymbolicValue]
 
 
+# TODO can be anything!
+class SymbolicVariableReference(SymbolicValue):
+    """Represents a symbolic variable reference.
+
+    Attributes
+    ----------
+    variable: str
+        The name of the value that is referenced.
+    type: SymbolicValueType
+        The type of the referenced variable.
+    """
+    variable: str
+    type_: SymbolicValueType
+
+
 @attr.s(frozen=True, auto_attribs=True, slots=True)
 class SymbolicParameter:
     """Provides the definition for a symbolic function parameter."""
+    index: int
     name: str
+    type_: SymbolicValueType
 
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -7,6 +7,7 @@ __all__ = (
     "SymbolicFunction",
     "SymbolicStatement",
     "SymbolicString",
+    "SymbolicProgram",
 )
 
 import abc
@@ -76,3 +77,15 @@ class SymbolicFunction:
     """
     name: str
     body: SymbolicCompound
+
+
+@attr.s(frozen=True, auto_attribs=True, slots=True)
+class SymbolicProgram:
+    """Provides a symbolic summary for a given program.
+
+    Attributes
+    ----------
+    functions: t.Mapping[str, SymbolicFunction]
+        The symbolic functions within this program, indexed by name.
+    """
+    functions: t.Mapping[str, SymbolicFunction]

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 __all__ = (
     "SymbolicBool",
+    "SymbolicCompound",
     "SymbolicFunction",
     "SymbolicStatement",
     "SymbolicString",
@@ -62,5 +65,14 @@ class SymbolicFunctionCall(SymbolicFunction):
 
 @attr.s(frozen=True, auto_attribs=True, slots=True)
 class SymbolicFunction:
+    """Provides the definition of a single symbolic function.
+
+    Attributes
+    ----------
+    name: str
+        The fully-qualified name of the function.
+    body: SymbolicCompound
+        The definition of the function.
+    """
     name: str
     body: SymbolicCompound

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -44,7 +44,7 @@ class SymbolicValue(abc.ABC):
     """Represents a symbolic value in a function summary."""
 
 
-class SymbolicString(abc.ABC, SymbolicValue):
+class SymbolicString(SymbolicValue, abc.ABC):
     """Represents a symbolic string value."""
 
 
@@ -54,11 +54,11 @@ class StringLiteral(SymbolicString):
     value: str
 
 
-class SymbolicInteger(abc.ABC, SymbolicValue):
+class SymbolicInteger(SymbolicValue, abc.ABC):
     """Represents a symbolic integer value."""
 
 
-class SymbolicBool(abc.ABC, SymbolicValue):
+class SymbolicBool(SymbolicValue, abc.ABC):
     """Represents a symbolic boolean value."""
 
 
@@ -89,7 +89,16 @@ class SymbolicCompound(t.Sequence[SymbolicStatement]):
     def __len__(self) -> int:
         return len(self._statements)
 
-    def __getitem__(self, at: t.Union[int, slice]) -> SymbolicStatement:
+    @t.overload
+    def __getitem__(self, at: int) -> SymbolicStatement: ...
+
+    @t.overload
+    def __getitem__(self, at: slice) -> t.Sequence[SymbolicStatement]: ...
+
+    def __getitem__(
+        self,
+        at: t.Union[int, slice],
+    ) -> t.Union[SymbolicStatement, t.Sequence[SymbolicStatement]]:
         return self._statements[at]
 
 

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -27,6 +27,9 @@ class SymbolicValueType(enum.Enum):
     STRING = "string"
     UNSUPPORTED = "unsupported"
 
+    def __str__(self) -> str:
+        return self.value
+
     @classmethod
     def from_name(cls, name: str) -> SymbolicValueType:
         name_to_type = {
@@ -172,7 +175,7 @@ class SymbolicVariableReference(SymbolicValue):
         return {
             "kind": "variable-reference",
             "variable": self.variable,
-            "type": self.type_,
+            "type": str(self.type_),
         }
 
 
@@ -187,7 +190,7 @@ class SymbolicParameter:
         return {
             "index": self.index,
             "name": self.name,
-            "type": self.type_.value,
+            "type": str(self.type_),
         }
 
 
@@ -243,4 +246,4 @@ class SymbolicProgram:
         return SymbolicProgram(name_to_function)
 
     def to_dict(self) -> t.Dict[str, t.Any]:
-        return {"program": {name: f for (name, f) in self.functions.items()}}
+        return {"program": {name: f.to_dict() for (name, f) in self.functions.items()}}

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -118,7 +118,7 @@ class SymbolicFunctionCall(SymbolicStatement):
     arguments: t.Mapping[str, SymbolicValue]
 
 
-# TODO can be anything!
+@attr.s(frozen=True, auto_attribs=True, slots=True)
 class SymbolicVariableReference(SymbolicValue):
     """Represents a symbolic variable reference.
 

--- a/src/rosdiscover/recover/tool.py
+++ b/src/rosdiscover/recover/tool.py
@@ -273,9 +273,9 @@ class NodeRecoveryTool:
 
         compile_commands_path = self._find_compile_commands_file(package)
 
-        self._recover(compile_commands_path, sources)
+        # recover a symbolic description of the node executable
+        program = self._recover(compile_commands_path, sources)
 
-        # FIXME for now, we just return a dummy recovered model
         package_abs_path = self._app.description.packages[package_name].path
         return RecoveredNodeModel(
             image_sha256=self._app.sha256,
@@ -283,6 +283,7 @@ class NodeRecoveryTool:
             package_abs_path=package_abs_path,
             source_paths=tuple(sources),
             node_name=node_name,
+            program=program,
         )
 
     def _recover(
@@ -358,4 +359,6 @@ class NodeRecoveryTool:
         model_loader = SymbolicProgramLoader()
         json_model_file_contents = files.read(json_model_filename, binary=False)
         json_model = json.loads(json_model_file_contents)
-        return model_loader.load(json_model)
+        summary = model_loader.load(json_model)
+        logger.debug(f"recovered node summary: {summary}")
+        return summary

--- a/src/rosdiscover/recover/tool.py
+++ b/src/rosdiscover/recover/tool.py
@@ -15,6 +15,7 @@ import roswire
 
 from .loader import SymbolicProgramLoader
 from .model import RecoveredNodeModel
+from .symbolic import SymbolicProgram
 from ..config import Config
 
 


### PR DESCRIPTION
Note that this PR does not provide an interpreter for the recovered models. I'll spin that up on a separate PR to keep things moving faster.

To quickly demonstrate this functionality:
```
$ pipenv run rosdiscover launch example/chatter.yml
```