### PR TITLE
Provide more direct access to the ROS distribution in the context

### DIFF
--- a/src/rosdiscover/interpreter/context.py
+++ b/src/rosdiscover/interpreter/context.py
@@ -4,7 +4,7 @@ from typing import Any, List, Mapping, Optional, Set, Tuple
 from loguru import logger
 import attr
 import dockerblade
-from roswire import AppInstance, ROSVersion
+from roswire import AppInstance, ROSDistribution, ROSVersion
 import roswire.name as rosname
 import typing
 
@@ -57,6 +57,10 @@ class NodeContext:
         if ns[-1] != '/':
             ns += ' /'
         return f'{ns}{self.name}'
+
+    @property
+    def ros_distro(self) -> ROSDistribution:
+        return self.app.description.distribution
 
     def _apply_remappings(self, name: str) -> str:
         """Applies any appropriate remappings to a fully qualified name."""
@@ -199,7 +203,7 @@ class NodeContext:
                      f"[{ns}] with format [{fmt}]")
         ns = self.resolve(ns)
         self._action_servers.add(Action(name=ns, format=fmt))
-        if self.app.description.distribution.ros == ROSVersion.ROS1:
+        if self.ros_distro.ros == ROSVersion.ROS1:
             # Topics are implicit because they are created by the action server
             # and are only really intended for interaction between the
             # action client and action server.
@@ -224,7 +228,7 @@ class NodeContext:
         ns = self.resolve(ns)
         self._action_clients.add(Action(name=ns, format=fmt))
 
-        if self.app.description.distribution.ros == ROSVersion.ROS1:
+        if self.ros_distro.ros == ROSVersion.ROS1:
             # Topics are implicit because they are created by the action client
             # and are only really intended for interaction between the
             # action client and action server.

--- a/src/rosdiscover/models/joint_state_publisher.py
+++ b/src/rosdiscover/models/joint_state_publisher.py
@@ -1,8 +1,10 @@
-from ..interpreter import model
+from roswire import ROSDistribution
+
+from ..interpreter import model, NodeContext
 
 
 @model('joint_state_publisher', 'joint_state_publisher')
-def joint_state_publisher(c):
+def joint_state_publisher(c: NodeContext):
     # https://github.com/ros/joint_state_publisher/blob/kinetic-devel/joint_state_publisher/joint_state_publisher/joint_state_publisher
 
     # joint_state_publisher#L33
@@ -19,7 +21,9 @@ def joint_state_publisher(c):
     get_param("publish_default_positions", True)
     get_param("publish_default_velocities", False)
     get_param("publish_default_efforts", False)
-    get_param("use_gui", False)
+
+    if c.ros_distro < ROSDistribution.NOETIC:
+        get_param("use_gui", False)
 
     for source in get_param("source_list", []):
         c.sub(source, 'sensor_msgs/JointState')


### PR DESCRIPTION
This could previously be gotten via the `app` property, but to make it easier to use in component models, we provide a shortcut.