### PR TITLE
Add entrypoint specification for node recovery

### DIFF
--- a/src/rosdiscover/cli.py
+++ b/src/rosdiscover/cli.py
@@ -25,7 +25,7 @@ def recover(args: argparse.Namespace) -> None:
     config = Config.from_yaml_string(args.config)
     with NodeRecoveryTool.for_config(config) as tool:
         print(f"spun up the container: {tool}")
-        tool.recover(args.package, args.node, args.sources)
+        tool.recover(args.package, args.node, args.entry, args.sources)
 
 
 def _launch(config: Config) -> SystemSummary:
@@ -139,6 +139,7 @@ def main() -> None:
     p.add_argument('config', type=argparse.FileType('r'), help=CONFIG_HELP)
     p.add_argument('package', type=str, help='the name of the package to which the node belongs')
     p.add_argument('node', type=str, help='the name of the node')
+    p.add_argument('entry', type=str, help='the function to use as an entry point')
     p.add_argument(
         'sources',
         nargs='+',

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -96,7 +96,7 @@ class NodeSourceInfo:
             package_name=dict_['package'],
             node_name=dict_['node'],
             node_kind=kind,
-            entrypoint=dict_['entrypoint'],
+            entrypoint=dict_.get('entrypoint'),
             sources=list(dict_['sources'])
         )
 

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -42,7 +42,7 @@ class NodeSourceInfo:
         The name of the node provided by the package
     node_kind: ROSNodeKind
         The kind of node represented
-    entry_point: str
+    entrypoint: str
         The entry point for the main program in the source. The format for this is
         a fully qualified classname, followed by the name of the function, like:
         qualified.class.name::main
@@ -52,7 +52,7 @@ class NodeSourceInfo:
     package_name: str
     node_name: str
     node_kind: ROSNodeKind
-    entry_point: str
+    entrypoint: str
     sources: t.Sequence[str]
 
     @classmethod
@@ -73,17 +73,6 @@ class NodeSourceInfo:
             raise ValueError("'node' is undefined for the node source.")
         if 'sources' not in dict_:
             raise ValueError("'sources' is undefined for the node source.")
-        if 'entry_point' not in dict_:
-            raise ValueError("'entry_point' is undefined for the node source.")
-
-        if not isinstance(dict_['package'], str):
-            raise ValueError("expected 'package' to be a string")
-        if not isinstance(dict_['node'], str):
-            raise ValueError("expected 'node' to be a string")
-        if not isinstance(dict_['sources'], list):
-            raise ValueError("expected 'sources' to be a list")
-        if not isinstance(dict_['entry_point'], str):
-            raise ValueError("expected 'entry_point' to be a string")
 
         kind = ROSNodeKind.NODE
         if 'kind' in dict_:
@@ -91,11 +80,23 @@ class NodeSourceInfo:
                 raise ValueError("expected 'kind' to be a string")
             kind = ROSNodeKind.value_of(dict_['kind'])
 
+        if kind == ROSNodeKind.NODELET and 'entrypoint' not in dict_:
+            raise ValueError("'entrypoint' is undefined for the nodelet source.")
+
+        if not isinstance(dict_['package'], str):
+            raise ValueError("expected 'package' to be a string")
+        if not isinstance(dict_['node'], str):
+            raise ValueError("expected 'node' to be a string")
+        if not isinstance(dict_['sources'], list):
+            raise ValueError("expected 'sources' to be a list")
+        if 'entrypoint' in dict_ and not isinstance(dict_['entrypoint'], str):
+            raise ValueError("expected 'entrypoint' to be a string")
+
         return NodeSourceInfo(
             package_name=dict_['package'],
             node_name=dict_['node'],
             node_kind=kind,
-            entry_point=dict_['entry_point'],
+            entrypoint=dict_['entrypoint'],
             sources=list(dict_['sources'])
         )
 

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -75,6 +75,8 @@ class NodeSourceInfo:
             raise ValueError("'sources' is undefined for the node source.")
 
         kind = ROSNodeKind.NODE
+        entrypoint = "main"
+
         if 'kind' in dict_:
             if not isinstance(dict_['kind'], str):
                 raise ValueError("expected 'kind' to be a string")
@@ -89,14 +91,16 @@ class NodeSourceInfo:
             raise ValueError("expected 'node' to be a string")
         if not isinstance(dict_['sources'], list):
             raise ValueError("expected 'sources' to be a list")
-        if 'entrypoint' in dict_ and not isinstance(dict_['entrypoint'], str):
-            raise ValueError("expected 'entrypoint' to be a string")
+        if 'entrypoint' in dict_:
+            if not isinstance(dict_['entrypoint'], str):
+                raise ValueError("expected 'entrypoint' to be a string")
+            entrypoint = dict_['entrypoint']
 
         return NodeSourceInfo(
             package_name=dict_['package'],
             node_name=dict_['node'],
             node_kind=kind,
-            entrypoint=dict_.get('entrypoint'),
+            entrypoint=entrypoint,
             sources=list(dict_['sources'])
         )
 

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -40,14 +40,19 @@ class NodeSourceInfo:
         The name of the package where the node is from
     node_name: str
         The name of the node provided by the package
-    node_type: ROSNodeKind
+    node_kind: ROSNodeKind
         The kind of node represented
+    entry_point: str
+        The entry point for the main program in the source. The format for this is
+        a fully qualified classname, followed by the name of the function, like:
+        qualified.class.name::main
     sources: Sequence[str]
         The list of sources for building the node
     """
     package_name: str
     node_name: str
     node_kind: ROSNodeKind
+    entry_point: str
     sources: t.Sequence[str]
 
     @classmethod
@@ -68,6 +73,8 @@ class NodeSourceInfo:
             raise ValueError("'node' is undefined for the node source.")
         if 'sources' not in dict_:
             raise ValueError("'sources' is undefined for the node source.")
+        if 'entry_point' not in dict_:
+            raise ValueError("'entry_point' is undefined for the node source.")
 
         if not isinstance(dict_['package'], str):
             raise ValueError("expected 'package' to be a string")
@@ -75,6 +82,8 @@ class NodeSourceInfo:
             raise ValueError("expected 'node' to be a string")
         if not isinstance(dict_['sources'], list):
             raise ValueError("expected 'sources' to be a list")
+        if not isinstance(dict_['entry_point'], str):
+            raise ValueError("expected 'entry_point' to be a string")
 
         kind = ROSNodeKind.NODE
         if 'kind' in dict_:
@@ -86,6 +95,7 @@ class NodeSourceInfo:
             package_name=dict_['package'],
             node_name=dict_['node'],
             node_kind=kind,
+            entry_point=dict_['entry_point'],
             sources=list(dict_['sources'])
         )
 

--- a/src/rosdiscover/project/models.py
+++ b/src/rosdiscover/project/models.py
@@ -73,7 +73,7 @@ class ProjectModels:
         node_info = self.config.node_sources[(package, node)]
 
         # use the recovery tool to recover the model before saving it to the database
-        model = self._recovery_tool.recover(package, node, node_info.entry_point, node_info.sources)
+        model = self._recovery_tool.recover(package, node, node_info.entrypoint, node_info.sources)
         self._recovered_models.store(model)
         return model
 

--- a/src/rosdiscover/project/models.py
+++ b/src/rosdiscover/project/models.py
@@ -70,10 +70,10 @@ class ProjectModels:
         # TODO we need to know the sources for this node
         # - eventually, we want this to come from CMakeLists
         # - for now, we can manually specify these as part of the configuration
-        sources = self.config.node_sources[(package, node)].sources
+        node_info = self.config.node_sources[(package, node)]
 
         # use the recovery tool to recover the model before saving it to the database
-        model = self._recovery_tool.recover(package, node, sources)
+        model = self._recovery_tool.recover(package, node, node_info.entry_point, node_info.sources)
         self._recovered_models.store(model)
         return model
 

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -181,6 +181,6 @@ class SymbolicProgramLoader:
     def load(self, dict_: t.Mapping[str, t.Any]) -> SymbolicProgram:
         dict_ = dict_["program"]
         return SymbolicProgram.build(
-            "main",
+            dict_["entry_point"],
             (self._load_function(d) for d in dict_["functions"])
         )

--- a/src/rosdiscover/recover/loader.py
+++ b/src/rosdiscover/recover/loader.py
@@ -181,5 +181,6 @@ class SymbolicProgramLoader:
     def load(self, dict_: t.Mapping[str, t.Any]) -> SymbolicProgram:
         dict_ = dict_["program"]
         return SymbolicProgram.build(
-            self._load_function(d) for d in dict_["functions"]
+            "main",
+            (self._load_function(d) for d in dict_["functions"])
         )

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -380,7 +380,7 @@ class SymbolicProgram:
         }
 
     @property
-    def entry_fn(self) -> SymbolicFunction:
+    def entrypoint(self) -> SymbolicFunction:
         """Returns the main function (i.e., entrypoint) for this program."""
         return self.functions[self.entrypoint]
 

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -372,6 +372,7 @@ class SymbolicProgram:
     def to_dict(self) -> t.Dict[str, t.Any]:
         return {
             "program": {
+                "entry_point": self.entry_point,
                 "functions": [f.to_dict() for f in self.functions.values()],
             },
         }

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -352,7 +352,7 @@ class SymbolicProgram:
     ValueError
         If this program does not provide a "main" function.
     """
-    entry_point: str
+    entry_point: str = attr.ib()
     functions: t.Mapping[str, SymbolicFunction] = attr.ib()
 
     @functions.validator

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -365,9 +365,11 @@ class SymbolicProgram:
             raise ValueError(f"symbolic programs must provide a '{self.entrypoint}' function")
 
     @classmethod
-    def build(cls, entry_point: str, functions: t.Iterable[SymbolicFunction]) -> SymbolicProgram:
+    def build(cls, entrypoint: str, functions: t.Iterable[SymbolicFunction]) -> SymbolicProgram:
         name_to_function = {function.name: function for function in functions}
-        return SymbolicProgram(entry_point, name_to_function)
+        if entrypoint not in name_to_function:
+            raise ValueError(f"The entrypoint '{entrypoint}' is unknown in the program.")
+        return SymbolicProgram(entrypoint, name_to_function)
 
     def to_dict(self) -> t.Dict[str, t.Any]:
         return {

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -343,7 +343,7 @@ class SymbolicProgram:
     ----------
     entrypoint: str
         The name of the function that serves as the entry point for the
-        proagram.
+        program.
     functions: t.Mapping[str, SymbolicFunction]
         The symbolic functions within this program, indexed by name.
 

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -341,7 +341,7 @@ class SymbolicProgram:
 
     Attributes
     ----------
-    entry_point: str
+    entrypoint: str
         The name of the function that serves as the entry point for the
         proagram.
     functions: t.Mapping[str, SymbolicFunction]
@@ -352,7 +352,7 @@ class SymbolicProgram:
     ValueError
         If this program does not provide a "main" function.
     """
-    entry_point: str = attr.ib()
+    entrypoint: str = attr.ib()
     functions: t.Mapping[str, SymbolicFunction] = attr.ib()
 
     @functions.validator
@@ -361,8 +361,8 @@ class SymbolicProgram:
         attribute: str,
         value: t.Any,
     ) -> None:
-        if self.entry_point not in self.functions:
-            raise ValueError(f"symbolic programs must provide a '{self.entry_point}' function")
+        if self.entrypoint not in self.functions:
+            raise ValueError(f"symbolic programs must provide a '{self.entrypoint}' function")
 
     @classmethod
     def build(cls, entry_point: str, functions: t.Iterable[SymbolicFunction]) -> SymbolicProgram:
@@ -372,7 +372,7 @@ class SymbolicProgram:
     def to_dict(self) -> t.Dict[str, t.Any]:
         return {
             "program": {
-                "entry_point": self.entry_point,
+                "entry_point": self.entrypoint,
                 "functions": [f.to_dict() for f in self.functions.values()],
             },
         }
@@ -380,7 +380,7 @@ class SymbolicProgram:
     @property
     def entry_fn(self) -> SymbolicFunction:
         """Returns the main function (i.e., entrypoint) for this program."""
-        return self.functions[self.entry_point]
+        return self.functions[self.entrypoint]
 
     def eval(self, node: NodeContext) -> None:
         context = SymbolicContext.create(self, node)

--- a/src/rosdiscover/recover/symbolic.py
+++ b/src/rosdiscover/recover/symbolic.py
@@ -52,7 +52,7 @@ class SymbolicContext:
     ) -> SymbolicContext:
         return SymbolicContext(
             program=program,
-            function=program.entry_fn,
+            function=program.entrypoint,
             node=node,
         )
 
@@ -352,7 +352,7 @@ class SymbolicProgram:
     ValueError
         If this program does not provide a "main" function.
     """
-    entrypoint: str = attr.ib()
+    entrypoint_name: str = attr.ib()
     functions: t.Mapping[str, SymbolicFunction] = attr.ib()
 
     @functions.validator
@@ -361,8 +361,8 @@ class SymbolicProgram:
         attribute: str,
         value: t.Any,
     ) -> None:
-        if self.entrypoint not in self.functions:
-            raise ValueError(f"symbolic programs must provide a '{self.entrypoint}' function")
+        if self.entrypoint_name not in self.functions:
+            raise ValueError(f"symbolic programs must provide a '{self.entrypoint_name}' function")
 
     @classmethod
     def build(cls, entrypoint: str, functions: t.Iterable[SymbolicFunction]) -> SymbolicProgram:
@@ -374,7 +374,7 @@ class SymbolicProgram:
     def to_dict(self) -> t.Dict[str, t.Any]:
         return {
             "program": {
-                "entry_point": self.entrypoint,
+                "entry_point": self.entrypoint_name,
                 "functions": [f.to_dict() for f in self.functions.values()],
             },
         }
@@ -382,8 +382,8 @@ class SymbolicProgram:
     @property
     def entrypoint(self) -> SymbolicFunction:
         """Returns the main function (i.e., entrypoint) for this program."""
-        return self.functions[self.entrypoint]
+        return self.functions[self.entrypoint_name]
 
     def eval(self, node: NodeContext) -> None:
         context = SymbolicContext.create(self, node)
-        self.entry_fn.body.eval(context)
+        self.entrypoint.body.eval(context)

--- a/src/rosdiscover/recover/tool.py
+++ b/src/rosdiscover/recover/tool.py
@@ -232,6 +232,7 @@ class NodeRecoveryTool:
         self,
         package_name: str,
         node_name: str,
+        entry_point: str,
         sources: t.Collection[str],
     ) -> RecoveredNodeModel:
         """Statically recovers the dynamic architecture of a given node.
@@ -242,6 +243,8 @@ class NodeRecoveryTool:
             The name of the package to which the node belongs
         node_name: str
             The name of the node
+        entry_point: str
+            The function that represents the entry_point for the node (e.g., main)
         sources: str
             A list of the translation unit source files for node, provided as paths
             relative to the root of the package directory
@@ -274,7 +277,7 @@ class NodeRecoveryTool:
         compile_commands_path = self._find_compile_commands_file(package)
 
         # recover a symbolic description of the node executable
-        program = self._recover(compile_commands_path, sources)
+        program = self._recover(compile_commands_path, entry_point, sources)
 
         package_abs_path = self._app.description.packages[package_name].path
         return RecoveredNodeModel(
@@ -289,6 +292,7 @@ class NodeRecoveryTool:
     def _recover(
         self,
         compile_commands_path: str,
+        entry_point: str,
         source_file_abs_paths: t.Collection[str],
     ) -> SymbolicProgram:
         """Invokes the C++ recovery binary to recover the dynamic architecture of a given node.
@@ -297,6 +301,8 @@ class NodeRecoveryTool:
         ----------
         compile_commands_path: str
             The absolute path to the compile_commands.json associated with the given node.
+        entry_point: str
+            The name of the function that is the entry point for the symbolic program.
         source_file_abs_paths: str
             A list of the C++ translation unit source files (i.e., .cpp files)
             for the given node, provided as absolute paths within the container


### PR DESCRIPTION
The entrypoint for a node could be `main` or `onInit`. So, specify this in the config file.