### PR TITLE
Added a CLI command for fetching all node/nodelet sources in a given image

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ coveralls = "==2.0.0"
 twine = "==3.1.1"
 types-setuptools = "==57.0.0"
 types-PyYAML = "==5.4.3"
-roswire = {editable = true, ref = "ba989720b2bcfccdd09fa7fd534fc2fb533816da", git = "https://github.com/rosqual/roswire"}
+roswire = {editable = true, ref = "5d757f4e05462998bed177a1cc5db3467d220c63", git = "https://github.com/rosqual/roswire"}
 
 [dev-packages]
 flake8 = "==3.8.2"

--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ coveralls = "==2.0.0"
 twine = "==3.1.1"
 types-setuptools = "==57.0.0"
 types-PyYAML = "==5.4.3"
-roswire = {editable = true, ref = "8f6db9bfa70660c1ff52caa496642a4d423fba65", git = "https://github.com/rosqual/roswire"}
+roswire = {editable = true, ref = "ba989720b2bcfccdd09fa7fd534fc2fb533816da", git = "https://github.com/rosqual/roswire"}
 
 [dev-packages]
 flake8 = "==3.8.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f0dca4d1013c1c80bd33b638f3242704880b0ba26dfe7a04931223df0d937d8d"
+            "sha256": "a905edf5021bc96105d51103f43a8449fc86c58720ea01b58027d04332294347"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -316,11 +316,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:70401259e46e216056367a0a6034ee3d3f95e0bf59d3aa6a4eb77837171ed996",
-                "sha256:8c746e0d09871661520da4f1241ba6b908dc903839733c8203b552cffaf173bd"
+                "sha256:1debcabeb1df793814859d64a81ad7cb10504c24349368ccf214c664c474f41f",
+                "sha256:56ddac45541718ba332db05f464bebfb0768110111affd27f66e0051f276fa43"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==8.9.0"
+            "version": "==8.10.0"
         },
         "mslex": {
             "hashes": [
@@ -549,7 +549,7 @@
         "roswire": {
             "editable": true,
             "git": "https://github.com/rosqual/roswire",
-            "ref": "ba989720b2bcfccdd09fa7fd534fc2fb533816da"
+            "ref": "5d757f4e05462998bed177a1cc5db3467d220c63"
         },
         "ruamel.yaml": {
             "hashes": [
@@ -997,11 +997,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:70401259e46e216056367a0a6034ee3d3f95e0bf59d3aa6a4eb77837171ed996",
-                "sha256:8c746e0d09871661520da4f1241ba6b908dc903839733c8203b552cffaf173bd"
+                "sha256:1debcabeb1df793814859d64a81ad7cb10504c24349368ccf214c664c474f41f",
+                "sha256:56ddac45541718ba332db05f464bebfb0768110111affd27f66e0051f276fa43"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==8.9.0"
+            "version": "==8.10.0"
         },
         "mypy": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3a9b455e5610e25358f821a825884799db8f84f14eba395ef54c16989f4b94d5"
+            "sha256": "f0dca4d1013c1c80bd33b638f3242704880b0ba26dfe7a04931223df0d937d8d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -549,7 +549,7 @@
         "roswire": {
             "editable": true,
             "git": "https://github.com/rosqual/roswire",
-            "ref": "8f6db9bfa70660c1ff52caa496642a4d423fba65"
+            "ref": "ba989720b2bcfccdd09fa7fd534fc2fb533816da"
         },
         "ruamel.yaml": {
             "hashes": [
@@ -682,11 +682,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:9ef4e8ee4710826e98ff3075c9a4739e2cb1040de6a2a8d35db0055840dc96a0",
-                "sha256:e4670891b3a03eb071748c569a87cceaefbf643c5bac46d996c5a45c34aa0f06"
+                "sha256:4da4ac43888e97de9cf4fdd870f48ed864bbfd133d2c46cbdec941fed4a25aef",
+                "sha256:a4b987ec31c3c9996cf1bc865332f967fe4a0512c41b39652d6224f696e69da5"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.7.2"
+            "version": "==20.8.0"
         },
         "wcwidth": {
             "hashes": [
@@ -711,7 +711,7 @@
             "version": "==1.2.1"
         },
         "zipp": {
-           "hashes": [
+            "hashes": [
                 "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3",
                 "sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4"
             ],
@@ -1262,11 +1262,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:9ef4e8ee4710826e98ff3075c9a4739e2cb1040de6a2a8d35db0055840dc96a0",
-                "sha256:e4670891b3a03eb071748c569a87cceaefbf643c5bac46d996c5a45c34aa0f06"
+                "sha256:4da4ac43888e97de9cf4fdd870f48ed864bbfd133d2c46cbdec941fed4a25aef",
+                "sha256:a4b987ec31c3c9996cf1bc865332f967fe4a0512c41b39652d6224f696e69da5"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.7.2"
+            "version": "==20.8.0"
         },
         "wcwidth": {
             "hashes": [

--- a/src/rosdiscover/cli.py
+++ b/src/rosdiscover/cli.py
@@ -124,6 +124,12 @@ def observe(args) -> None:
         print(yaml.dump(output, default_flow_style=False))
 
 
+def sources(args: argparse.Namespace) -> None:
+    config = Config.from_yaml_string(args.config)
+    config.find_node_sources()
+    raise NotImplementedError
+
+
 def rostopic_list(args) -> None:
     summary = _launch_config(args)
     topics = set()
@@ -179,6 +185,19 @@ def main(args: t.Optional[t.Sequence[str]] = None) -> None:
         help='the paths of the translation unit source files for this node, relative to the package directory',
     )
     p.set_defaults(func=recover)
+
+    # ----------------- SOURCES --------------------
+    p = subparsers.add_parser(
+        "sources",
+        help="retrieves the sources for the nodes and nodelets in a given image",
+    )
+    p.add_argument("config", type=argparse.FileType("r"), help=CONFIG_HELP)
+    p.add_argument(
+        "--save-to",
+        default="sources.json",
+        help="the name of the file to which the sources should be written",
+    )
+    p.set_defaults(func=sources)
 
     # ----------------- LAUNCH --------------------
     p = subparsers.add_parser(

--- a/src/rosdiscover/cli.py
+++ b/src/rosdiscover/cli.py
@@ -126,8 +126,10 @@ def observe(args) -> None:
 
 def sources(args: argparse.Namespace) -> None:
     config = Config.from_yaml_string(args.config)
-    config.find_node_sources()
-    raise NotImplementedError
+    config_with_sources = config.with_recovered_node_sources()
+
+    with open(args.save_to, "w") as fh:
+        yaml.dump(config_with_sources.to_dict(), fh, default_flow_style=False)
 
 
 def rostopic_list(args) -> None:
@@ -194,8 +196,8 @@ def main(args: t.Optional[t.Sequence[str]] = None) -> None:
     p.add_argument("config", type=argparse.FileType("r"), help=CONFIG_HELP)
     p.add_argument(
         "--save-to",
-        default="sources.json",
-        help="the name of the file to which the sources should be written",
+        default="config-with-sources.yml",
+        help="the name of the file to which the configuration with sources should be written",
     )
     p.set_defaults(func=sources)
 

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -280,6 +280,8 @@ class Config:
             return self.__cmake_binary_to_node_sources(package, target)
         elif isinstance(target, roswire.common.source.CMakeLibraryTarget):
             return self.__cmake_library_to_node_sources(package, target)
+        else:
+            raise ValueError("CMakeTarget is neither a binary or library")
 
     def __cmake_library_to_node_sources(
         self,

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -19,6 +19,9 @@ class ROSNodeKind(enum.Enum):
     NODE = "node"
     NODELET = "nodelet"
 
+    def __str__(self) -> str:
+        return self.value
+
     @classmethod
     def value_of(cls, value: str) -> "ROSNodeKind":
         if 'node' == value:
@@ -119,6 +122,16 @@ class NodeSourceInfo:
             sources=list(dict_['sources']),
             restrict_to_paths=restricted_paths
         )
+
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "package": self.package_name,
+            "node": self.node_name,
+            "kind": str(self.node_kind),
+            "entrypoint": self.entrypoint,
+            "restrict-analysis-to-paths": list(self.restrict_to_paths),
+            "sources": list(self.sources),
+        }
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -226,7 +226,7 @@ class Config:
                     package = package_cmake_targets.package
                     targets = package_cmake_targets.targets
                     for target in targets:
-                        node_sources = __cmake_target_to_node_sources(package, target)
+                        node_sources = self.__cmake_target_to_node_sources(package, target)
                         if not node_sources:
                             continue
 

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 __all__ = ('Config',)
 
 from types import MappingProxyType
@@ -212,11 +214,32 @@ class Config:
         else:
             launches = list(map(lambda s: Launch(filename=s, arguments=dict()), launches_inputs))
 
-        return Config(image=image,
-                      sources=sources,
-                      launches=launches,
-                      environment=environment,
-                      node_sources=node_sources)
+        return Config(
+            image=image,
+            sources=sources,
+            launches=launches,
+            environment=environment,
+            node_sources=node_sources,
+        )
+
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "image": self.image,
+            "sources": self.sources,
+            "launches": [l.to_dict() for l in self.launches],
+            "environment": dict(self.environment),
+            "node_sources": [s.to_dict() for s in self.node_sources.values()],
+        }
+
+    def with_recovered_node_sources(self) -> "Config":
+        recovered_node_sources = self.find_node_sources()
+        return Config(
+            image=self.image,
+            sources=list(self.sources),
+            launches=list(self.launches),
+            environment=dict(self.environment),
+            node_sources=recovered_node_sources,
+        )
 
     def find_node_sources(self) -> t.Mapping[t.Tuple[str, str], NodeSourceInfo]:
         """Determines the sources for each node and nodelet in the associated image.

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -225,7 +225,7 @@ class Config:
     def to_dict(self) -> t.Dict[str, t.Any]:
         return {
             "image": self.image,
-            "sources": self.sources,
+            "sources": list(self.sources),
             "launches": [launch.to_dict() for launch in self.launches],
             "environment": dict(self.environment),
             "node_sources": [s.to_dict() for s in self.node_sources.values()],

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -226,7 +226,7 @@ class Config:
         return {
             "image": self.image,
             "sources": self.sources,
-            "launches": [l.to_dict() for l in self.launches],
+            "launches": [launch.to_dict() for launch in self.launches],
             "environment": dict(self.environment),
             "node_sources": [s.to_dict() for s in self.node_sources.values()],
         }

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -276,10 +276,10 @@ class Config:
         package: roswire.common.Package,
         target: roswire.common.CMakeTarget,
     ) -> t.Optional[NodeSourceInfo]:
-        if isinstance(target, roswire.common.source.CMakeBinaryTarget):
-            return self.__cmake_binary_to_node_sources(package, target)
-        elif isinstance(target, roswire.common.source.CMakeLibraryTarget):
+        if isinstance(target, roswire.common.source.CMakeLibraryTarget):
             return self.__cmake_library_to_node_sources(package, target)
+        elif isinstance(target, roswire.common.source.CMakeBinaryTarget):
+            return self.__cmake_binary_to_node_sources(package, target)
         else:
             raise ValueError("CMakeTarget is neither a binary or library")
 

--- a/src/rosdiscover/config.py
+++ b/src/rosdiscover/config.py
@@ -288,6 +288,8 @@ class Config:
         package: roswire.common.Package,
         target: roswire.common.source.CMakeLibraryTarget,
     ) -> t.Optional[NodeSourceInfo]:
+        assert target.name is not None
+
         # not all libraries are nodelets
         if not target.entrypoint:
             return None
@@ -298,7 +300,7 @@ class Config:
             node_kind=ROSNodeKind.NODELET,
             restrict_to_paths=target.restrict_to_paths,
             entrypoint=target.entrypoint,
-            sources=target.sources,
+            sources=list(target.sources),
         )
 
     def __cmake_binary_to_node_sources(
@@ -306,13 +308,14 @@ class Config:
         package: roswire.common.Package,
         target: roswire.common.source.CMakeBinaryTarget,
     ) -> t.Optional[NodeSourceInfo]:
+        assert target.name is not None
         return NodeSourceInfo(
             package_name=package.name,
             node_name=target.name,
             node_kind=ROSNodeKind.NODE,
             restrict_to_paths=target.restrict_to_paths,
             entrypoint="main",
-            sources=target.sources,
+            sources=list(target.sources),
         )
 
     @classmethod

--- a/src/rosdiscover/launch.py
+++ b/src/rosdiscover/launch.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 __all__ = ('Launch',)
 
-from typing import Any, Mapping, List
+import typing as t
 
 import attr
 
@@ -15,17 +15,23 @@ class Launch:
     ----------
     filename: str
         The file name of the launch files that should be launched
-    arguments: Mapping[str, str]
+    arguments: t.Mapping[str, str]
         A set of launch arguments that should be passed to roslaunch
     """
     filename: str
-    arguments: Mapping[str, str]
+    arguments: t.Mapping[str, str]
 
-    def get_argv(self) -> List[str]:
+    def get_argv(self) -> t.List[str]:
         return [f'{argk}:={self.arguments.get(argk)}' for argk in self.arguments.keys()]
 
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {
+            "filename": self.filename,
+            "arguments": dict(self.arguments),
+        }
+
     @classmethod
-    def from_dict(cls, dict_: Mapping[str, Any]) -> 'Launch':
+    def from_dict(cls, dict_: t.Mapping[str, t.Any]) -> 'Launch':
         """
         Raises
         ------
@@ -43,6 +49,6 @@ class Launch:
             raise ValueError("expected 'arguments' to be a mapping")
 
         filename: str = dict_['filename']
-        arguments: Mapping[str, str] = dict(dict_.get('arguments', {}))
+        arguments: t.Mapping[str, str] = dict(dict_.get('arguments', {}))
         return Launch(filename=filename,
                       arguments=arguments)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.4.0
-envlist = py36, py37, py38
+envlist = py39
 
 [pytest]
 testpaths = tests


### PR DESCRIPTION
This PR adds a new command `sources` that takes a ROSDiscover config file as input, uses the CMakeLists.txt parser to find the sources for ALL nodes and nodelets that appear in the associated image (not just the nodes that are referenced in the launch files), and emits a new configuration file that includes those recovered node sources.