### PR TITLE
Fix a bug where XML has a bunch of illegal characters before <robot> tag

### DIFF
--- a/src/rosdiscover/models/spawn_model.py
+++ b/src/rosdiscover/models/spawn_model.py
@@ -47,7 +47,7 @@ def spawn_model(c):
     begin_tag = "<robot>"
     begin_tag_starts_at = urdf_contents.find(begin_tag)
     if begin_tag_starts_at == -1:
-        begin_tag_starts_at.find("<robot ")
+        begin_tag_starts_at = urdf_contents.find("<robot ")
     if begin_tag_starts_at != -1:
         urdf_contents = urdf_contents[begin_tag_starts_at:]
 


### PR DESCRIPTION
Parser now assumes that everything before `<robot>` and after `</robot>` is dropped.