### PR TITLE
Error reproducer

### DIFF
--- a/src/rosdiscover/models/__init__.py
+++ b/src/rosdiscover/models/__init__.py
@@ -58,3 +58,4 @@ from . import velocity_smoother
 from . import pointgrey_camera_driver
 from . import lap_stats
 from . import rostopic
+from . import rosdiscover_error_reproducer

--- a/src/rosdiscover/models/rosdiscover_error_reproducer.py
+++ b/src/rosdiscover/models/rosdiscover_error_reproducer.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from ..interpreter import model, NodeContext
+
+@model('*', 'error_reproducer')
+def error_reproducer(c: NodeContext):
+    topics = c.read("~topic", [])
+    for t in topics:
+        if t["direction"] == 'pub':
+            c.pub(t["name"], t["type"])
+        elif t["direction"] == 'sub':
+            c.sub(t["name"], t["type"])

--- a/src/rosdiscover/models/rosdiscover_error_reproducer.py
+++ b/src/rosdiscover/models/rosdiscover_error_reproducer.py
@@ -4,6 +4,15 @@ from ..interpreter import model, NodeContext
 
 @model('*', 'error_reproducer')
 def error_reproducer(c: NodeContext):
+    """
+    This model is intended for evaluation of rosdiscover on
+    detecting misconfigurations. IT SHOULD NOT BE USED IN GENERAL.
+
+    This model subscribes and publishes to topics that are passed
+    in as parameters. In this way, we can easily construct a node
+    that can be used to reproduce a configuration error that exists
+    in our database.
+    """
     topics = c.read("~topic", [])
     for t in topics:
         if t["direction"] == 'pub':

--- a/src/rosdiscover/models/rosdiscover_error_reproducer.py
+++ b/src/rosdiscover/models/rosdiscover_error_reproducer.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from ..interpreter import model, NodeContext
 
+
 @model('*', 'error_reproducer')
 def error_reproducer(c: NodeContext):
     topics = c.read("~topic", [])

--- a/src/rosdiscover/project/models.py
+++ b/src/rosdiscover/project/models.py
@@ -97,6 +97,8 @@ class ProjectModels:
         logger.debug(f"Handwritten {package}/{node}")
         if HandwrittenModel.exists(package, node):
             return HandwrittenModel.fetch(package, node)
+        if HandwrittenModel.exists("*", node):
+            return HandwrittenModel.fetch("*", node)
         return None
 
     def _fetch_placeholder(self, package: str, node: str) -> NodeModel:
@@ -140,14 +142,11 @@ class ProjectModels:
         if self.allow_recovery:
             model_sources.append(self._recover)
 
+        fetched_model: t.Optional[NodeModel] = None
         for model_source in model_sources:
-            try:
-                fetched_model = model_source(package, node)
-                if fetched_model:
-                    return fetched_model
-            except ValueError as ve:
-                logger.error("When trying to statically recover {package}/{node}, ecountered an error")
-                logger.exception(ve)
+            fetched_model = model_source(package, node)
+            if fetched_model:
+                return fetched_model
 
         if self.allow_placeholders:
             return self._fetch_placeholder(package, node)

--- a/src/rosdiscover/project/models.py
+++ b/src/rosdiscover/project/models.py
@@ -97,6 +97,10 @@ class ProjectModels:
         logger.debug(f"Handwritten {package}/{node}")
         if HandwrittenModel.exists(package, node):
             return HandwrittenModel.fetch(package, node)
+        # '*' is a placeholder for a package name. It's admittedly a hack, but it
+        # saves looking for packages that aren't on the system. It is used when
+        # we use dummy nodes for misconfiguration detection
+        # FIXME: Do something more principled.
         if HandwrittenModel.exists("*", node):
             return HandwrittenModel.fetch("*", node)
         return None


### PR DESCRIPTION
Add a error_reproducer handwritten model for reproducing some of the errors for the misconfiguration database in the cases where we can't detect them from the container because there are no users of the misconfigured things.