### PR TITLE
Refactor plugin model

### DIFF
--- a/src/rosdiscover/interpreter/interpreter.py
+++ b/src/rosdiscover/interpreter/interpreter.py
@@ -123,7 +123,7 @@ class Interpreter:
         # now that all nodes have been initialised, load all plugins
         for node_context in self.nodes.values():
             for plugin in node_context._plugins:
-                plugin.load(self)
+                plugin.load(self, node_context)
 
     def _create_nodelet_manager(self,
                                 name: str,

--- a/src/rosdiscover/interpreter/plugin.py
+++ b/src/rosdiscover/interpreter/plugin.py
@@ -4,6 +4,11 @@ __all__ = ('ModelPlugin',)
 import abc
 import typing
 
+import attr
+from loguru import logger
+
+from . import NodeContext
+
 if typing.TYPE_CHECKING:
     from .interpreter import Interpreter
 
@@ -12,6 +17,19 @@ class ModelPlugin(abc.ABC):
     """Models the architectural effects of a dynamically-loaded node plugin
     (e.g., a Gazebo plugin)."""
     @abc.abstractmethod
-    def load(self, interpreter: 'Interpreter') -> None:
+    def load(self, interpreter: 'Interpreter', context: NodeContext) -> None:
         """Simulates the effects of loading this plugin in a given context."""
         ...
+
+
+@attr.s(frozen=True, slots=True)
+class DynamicPlugin(abc.ABC):
+    """
+    Models dynamically loaded plygins, taking in a name of the plygin that
+    will be recovered when the plugin is loaded
+    """
+
+    name: str = attr.ib()
+
+    def load(self, interpreter: 'Interpreter', context: NodeContext) -> None:
+        logger.warning("Dynamic loading of plugins for {name} not implemented")

--- a/src/rosdiscover/interpreter/plugin.py
+++ b/src/rosdiscover/interpreter/plugin.py
@@ -22,14 +22,15 @@ class ModelPlugin(abc.ABC):
         ...
 
 
-@attr.s(frozen=True, slots=True)
-class DynamicPlugin(abc.ABC):
+class DynamicPlugin(type, ModelPlugin):
     """
     Models dynamically loaded plygins, taking in a name of the plygin that
     will be recovered when the plugin is loaded
     """
 
-    name: str = attr.ib()
-
     def load(self, interpreter: 'Interpreter', context: NodeContext) -> None:
         logger.warning("Dynamic loading of plugins for {name} not implemented")
+
+
+def generate_dynamic_plugin(plugin_name: str) -> type:
+    return type(f"{plugin_name}DynamicPlugin", (DynamicPlugin), {'plugin_name': plugin_name})

--- a/src/rosdiscover/models/plugins/navigation.py
+++ b/src/rosdiscover/models/plugins/navigation.py
@@ -62,8 +62,8 @@ class StaticLayerPlugin(NavigationPlugin):
     node_name: str = attr.ib()
     reference_name: t.Optional[str] = attr.ib()
 
-    def load(self, interpreter: Interpreter) -> None:
-        move_base = get_move_base(interpreter, self.node_name)
+    def load(self, interpreter: Interpreter, c: NodeContext) -> None:
+        move_base = c  # get_move_base(interpreter, self.node_name)
 
         move_base.read('~unknown_cost_value', -1)
         move_base.read('~lethal_cost_value', 100)


### PR DESCRIPTION
Currently, in plugins, a plugin needs to look up the node it's being loaded into. Refactored this so that the context is passed in when the plugin is loaded.